### PR TITLE
feat: upgrade do provider mgc and Addition of Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+**/terraform.tfstate
+**/terraform.tfstate.backup

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -82,18 +82,18 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/magalucloud/mgc" {
-  version     = "0.39.0"
-  constraints = "~> 0.39.0"
+  version     = "0.44.2"
+  constraints = "~> 0.44.0"
   hashes = [
-    "h1:3K4oW0ZuENRz6gU2sBHXhOaK1hPh9v7rQtewN/eAEj8=",
-    "zh:03033fcd618042630a2f1cbe40f67baba814b2b5b893e89afd527bec1b143d6e",
-    "zh:24f7921f55786511fce6aee7325758f3c5d63bf2847cb875a0784602d3167602",
-    "zh:44c93b52ba7ebacbc6a62a4ff640f5c8ac99bcff30cdc8cca96aa86d37bd8b44",
+    "h1:XYdzJfs/iZw7GJpHgsDUPrPEkYA8JuutUNT9D2rJX0w=",
+    "zh:38178ff0047b1462c56299a45eb95c83c4a749c754112a41efd02609bca8abc5",
+    "zh:66cf6b6be572674363e15419a8ceadb3306d3bfdd1063a9da10fea103e099381",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a8c8e523b798b1bf887a8c036710678d31e9424cb55c7674cd9c9e03670552a4",
-    "zh:b89b2e629841e5762d2e21180b7546cb83fe58b2315eaccd199bbae5532a4e16",
-    "zh:c1ec8b8830b523bf09d1cab017268421771062be81a1c7a72688e75da75f71b7",
-    "zh:cb3bda3a18cdcf062c399210e5ab5df86ffe5ba4058e2e268d7250aee6968e7c",
-    "zh:eb306e5feebc27142fec11bc0bfe5cd836c6ef6ba272f69a2bf67412ca683d7b",
+    "zh:b135a73bf415b5ff4dde0c98f7b76c6d1c98fc7ab927a9ea38d34f74de80fe07",
+    "zh:b5ac0233964e0f6cd4acf2f7f0c8a750ccbd7183c759dd2d9ea1ca2e879c19b6",
+    "zh:ce75e08a2634e5aba7b55ced2503f44904bb2aa4793ee052d6697b1daec4f631",
+    "zh:cf40e590cf7e878693d373f96da0a1e9b56d8d8f48066bc9e78fdc34d1fa1661",
+    "zh:f8a6fe46b543be4c5590c71cc2891730a336a8cbe95e5b3f19f65d96c13b46a8",
+    "zh:f92c6523d65361df066697a6e857942c963dd227749523d3428eaca2aa54856a",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.0](https://github.com/terraform-magalu-cloud/terraform-mgc-virtual-machine/compare/v2.1.0...v2.2.0) (2026-02-22)
+
+### Features
+
+* upgrade do provider mgc
+* adiciona Makefile com comandos padronizados para o ciclo de vida do Terraform (init, plan, apply, destroy, clean, fmt, validate e docs)
+
+### Bug Fixes
+
+* corrige a atribuição de 'ssh_key_name' na instância para usar a chave gerada quando 'ssh_key_create' é true
+* remove dependência inválida de variável local (resulting_security_group_ids) no bloco 'depends_on'
+* documenta reporte de bug referente à remoção de IP público ([issue #277](https://github.com/MagaluCloud/terraform-provider-mgc/issues/277))
+
 ## [2.1.0](https://github.com/terraform-magalu-cloud/terraform-mgc-virtual-machine/compare/v2.0.0...v2.1.0) (2025-10-20)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+.PHONY: all init plan apply destroy clean fmt validate
+
+# Define o diretório onde os comandos do terraform serão executados.
+# Padrão: examples/simple (comum para testar módulos)
+# Uso: make plan DIR=./caminho/do/exemplo
+DIR ?= examples/simple
+DIR2 ?= examples/advanced
+
+
+all: fmt init validate plan
+
+init:
+	@echo "Inicializando Terraform em $(DIR)..."
+	terraform init
+	cd $(DIR) && terraform init && cd -
+	cd $(DIR2) && terraform init && cd -
+
+plan:
+	@echo "Gerando plano de execução em $(DIR)..."
+	cd $(DIR) && terraform plan && cd -
+	cd $(DIR2) && terraform plan && cd -
+
+
+apply:
+	@echo "Aplicando mudanças em $(DIR)..."
+	cd $(DIR) && terraform apply -auto-approve && cd -
+	cd $(DIR2) && terraform apply -auto-approve && cd -
+
+
+destroy:
+	@echo "Destruindo recursos em $(DIR)..."
+	cd $(DIR) && terraform destroy -auto-approve && cd -
+	cd $(DIR2) && terraform destroy -auto-approve && cd -
+
+fmt:
+	@echo "Formatando arquivos Terraform recursivamente..."
+	terraform fmt -recursive
+
+validate:
+	@echo "Validando configuração..."
+	terraform validate
+	cd $(DIR) && terraform validate && cd -
+	cd $(DIR2) && terraform validate && cd -
+
+clean:
+	@echo "Limpando arquivos de cache (.terraform), locks e estados..."
+	find . -type d -name ".terraform" -prune -exec rm -rf {} +
+	find . -type f -name ".terraform.lock.hcl" -delete
+	find . -type f -name "*.tfstate" -delete
+	find . -type f -name "*.tfstate.backup" -delete

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all init plan apply destroy clean fmt validate
+.PHONY: all init plan apply destroy clean fmt validate docs pre-commit
 
 # Define o diretório onde os comandos do terraform serão executados.
 # Padrão: examples/simple (comum para testar módulos)
@@ -7,13 +7,13 @@ DIR ?= examples/simple
 DIR2 ?= examples/advanced
 
 
-all: fmt init validate plan
+all: docs fmt pre-commit init validate plan
 
 init:
 	@echo "Inicializando Terraform em $(DIR)..."
-	terraform init
-	cd $(DIR) && terraform init && cd -
-	cd $(DIR2) && terraform init && cd -
+	terraform init -upgrade
+	cd $(DIR) && terraform init -upgrade && cd -
+	cd $(DIR2) && terraform init -upgrade && cd -
 
 plan:
 	@echo "Gerando plano de execução em $(DIR)..."
@@ -48,3 +48,13 @@ clean:
 	find . -type f -name ".terraform.lock.hcl" -delete
 	find . -type f -name "*.tfstate" -delete
 	find . -type f -name "*.tfstate.backup" -delete
+
+pre-commit:
+	@echo "Executando pre-commit hooks..."
+	pre-commit run --all-files
+
+docs:
+	@echo "Gerando documentação com terraform-docs..."
+	terraform-docs .
+	cd $(DIR) && terraform-docs . && cd -
+	cd $(DIR2) && terraform-docs . && cd -

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This module was created and maintained by the community. If you want to help, se
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.5.2 |
-| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.39.0 |
+| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.44.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | 0.11.1 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.6 |
@@ -20,7 +20,7 @@ This module was created and maintained by the community. If you want to help, se
 | Name | Version |
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
-| <a name="provider_mgc"></a> [mgc](#provider\_mgc) | 0.39.0 |
+| <a name="provider_mgc"></a> [mgc](#provider\_mgc) | 0.44.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.11.1 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.6 |

--- a/examples/advanced/.terraform.lock.hcl
+++ b/examples/advanced/.terraform.lock.hcl
@@ -82,18 +82,18 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/magalucloud/mgc" {
-  version     = "0.39.0"
-  constraints = "~> 0.39.0"
+  version     = "0.44.2"
+  constraints = "~> 0.44.0"
   hashes = [
-    "h1:3K4oW0ZuENRz6gU2sBHXhOaK1hPh9v7rQtewN/eAEj8=",
-    "zh:03033fcd618042630a2f1cbe40f67baba814b2b5b893e89afd527bec1b143d6e",
-    "zh:24f7921f55786511fce6aee7325758f3c5d63bf2847cb875a0784602d3167602",
-    "zh:44c93b52ba7ebacbc6a62a4ff640f5c8ac99bcff30cdc8cca96aa86d37bd8b44",
+    "h1:XYdzJfs/iZw7GJpHgsDUPrPEkYA8JuutUNT9D2rJX0w=",
+    "zh:38178ff0047b1462c56299a45eb95c83c4a749c754112a41efd02609bca8abc5",
+    "zh:66cf6b6be572674363e15419a8ceadb3306d3bfdd1063a9da10fea103e099381",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a8c8e523b798b1bf887a8c036710678d31e9424cb55c7674cd9c9e03670552a4",
-    "zh:b89b2e629841e5762d2e21180b7546cb83fe58b2315eaccd199bbae5532a4e16",
-    "zh:c1ec8b8830b523bf09d1cab017268421771062be81a1c7a72688e75da75f71b7",
-    "zh:cb3bda3a18cdcf062c399210e5ab5df86ffe5ba4058e2e268d7250aee6968e7c",
-    "zh:eb306e5feebc27142fec11bc0bfe5cd836c6ef6ba272f69a2bf67412ca683d7b",
+    "zh:b135a73bf415b5ff4dde0c98f7b76c6d1c98fc7ab927a9ea38d34f74de80fe07",
+    "zh:b5ac0233964e0f6cd4acf2f7f0c8a750ccbd7183c759dd2d9ea1ca2e879c19b6",
+    "zh:ce75e08a2634e5aba7b55ced2503f44904bb2aa4793ee052d6697b1daec4f631",
+    "zh:cf40e590cf7e878693d373f96da0a1e9b56d8d8f48066bc9e78fdc34d1fa1661",
+    "zh:f8a6fe46b543be4c5590c71cc2891730a336a8cbe95e5b3f19f65d96c13b46a8",
+    "zh:f92c6523d65361df066697a6e857942c963dd227749523d3428eaca2aa54856a",
   ]
 }

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -8,15 +8,15 @@ This module was created and maintained by the community. If you want to help, se
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.39.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
+| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.44.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_mgc"></a> [mgc](#provider\_mgc) | 0.39.0 |
+| <a name="provider_mgc"></a> [mgc](#provider\_mgc) | 0.44.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules
@@ -32,6 +32,7 @@ This module was created and maintained by the community. If you want to help, se
 |------|------|
 | [random_string.sufix](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/string) | resource |
 | [mgc_virtual_machine_instance.first](https://registry.terraform.io/providers/MagaluCloud/mgc/latest/docs/data-sources/virtual_machine_instance) | data source |
+| [mgc_virtual_machine_snapshots.snaps](https://registry.terraform.io/providers/MagaluCloud/mgc/latest/docs/data-sources/virtual_machine_snapshots) | data source |
 
 ## Inputs
 
@@ -53,5 +54,6 @@ This module was created and maintained by the community. If you want to help, se
 | <a name="output_public_ipv4"></a> [public\_ipv4](#output\_public\_ipv4) | Public IPv4 address of the first network interface of the first virtual machine instance\_first. |
 | <a name="output_public_key"></a> [public\_key](#output\_public\_key) | Public key of the first virtual machine instance\_first. |
 | <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | List of security group IDs associated with the first virtual machine instance\_first. |
+| <a name="output_snapshots"></a> [snapshots](#output\_snapshots) | Snapshot list of the first virtual machine instance\_first. |
 | <a name="output_vm_instance_firsts"></a> [vm\_instance\_firsts](#output\_vm\_instance\_firsts) | Information about the first virtual machine instance\_first. |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of the VPC used by the first virtual machine instance\_first. |

--- a/examples/advanced/data.tf
+++ b/examples/advanced/data.tf
@@ -1,3 +1,6 @@
 data "mgc_virtual_machine_instance" "first" {
   id = module.instance_first.id
 }
+
+data "mgc_virtual_machine_snapshots" "snaps" {
+}

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -22,8 +22,7 @@ module "instance_first" {
   vpc_name                = "vpc_default"
   machine_type_name       = "BV2-2-10"
   create_from_snapshot_id = data.mgc_virtual_machine_snapshots.snaps.snapshots != null ? data.mgc_virtual_machine_snapshots.snaps.snapshots[0].id : null
-  #create_from_snapshot_
-  image_name = "cloud-ubuntu-24.04 LTS"
+  image_name              = "cloud-ubuntu-24.04 LTS"
   additional_disk = {
     vdb = {
       name      = "opt"
@@ -54,7 +53,6 @@ module "instance_second" {
   vpc_name              = "vpc_default"
   machine_type_name     = "BV2-2-10"
   image_name            = "cloud-ubuntu-24.04 LTS"
-  #create_from_snapshot_id = "12586af7-43d6-4229-9b29-2a93bd7d429b"
   additional_disk = {
     vdb = {
       name      = "opt"
@@ -69,5 +67,4 @@ module "instance_second" {
       encrypted = false
     }
   }
-  #security_group_names = ["panda-pub-party", "example-security-group", "sg-example-akSdVhOR"]
 }

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -10,19 +10,20 @@ resource "random_string" "sufix" {
 
 
 module "instance_first" {
-  source                = "../../"
-  create                = true
-  name                  = "first-${var.name}-${random_string.sufix.id}"
-  ssh_key_create        = true
-  ssh_key_name          = "first-${var.name}-${random_string.sufix.id}"
-  attach_public_ip      = true
-  backup_enabled        = true
-  backup_retention_days = 7
-  backup_schedule       = "03:00:00"
-  vpc_name              = "vpc_default"
-  machine_type_name     = "BV2-2-10"
-  #image_name            = "cloud-ubuntu-24.04 LTS"
-  create_from_snapshot_id = "12586af7-43d6-4229-9b29-2a93bd7d429b"
+  source                  = "../../"
+  create                  = true
+  name                    = "first-${var.name}-${random_string.sufix.id}"
+  ssh_key_create          = true
+  ssh_key_name            = "first-${var.name}-${random_string.sufix.id}"
+  attach_public_ip        = true
+  backup_enabled          = true
+  backup_retention_days   = 7
+  backup_schedule         = "03:00:00"
+  vpc_name                = "vpc_default"
+  machine_type_name       = "BV2-2-10"
+  create_from_snapshot_id = data.mgc_virtual_machine_snapshots.snaps.snapshots != null ? data.mgc_virtual_machine_snapshots.snaps.snapshots[0].id : null
+  #create_from_snapshot_
+  image_name = "cloud-ubuntu-24.04 LTS"
   additional_disk = {
     vdb = {
       name      = "opt"

--- a/examples/advanced/outputs.tf
+++ b/examples/advanced/outputs.tf
@@ -49,3 +49,8 @@ output "vm_instance_firsts" {
   description = "Information about the first virtual machine instance_first."
   value       = data.mgc_virtual_machine_instance.first
 }
+
+output "snapshots" {
+  description = "Snapshot list of the first virtual machine instance_first."
+  value       = data.mgc_virtual_machine_snapshots.snaps
+}

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mgc = {
       source  = "MagaluCloud/mgc"
-      version = "~> 0.39.0"
+      version = "~> 0.44.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/simple/.terraform.lock.hcl
+++ b/examples/simple/.terraform.lock.hcl
@@ -82,18 +82,18 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/magalucloud/mgc" {
-  version     = "0.39.0"
-  constraints = "~> 0.39.0"
+  version     = "0.44.2"
+  constraints = "~> 0.44.0"
   hashes = [
-    "h1:3K4oW0ZuENRz6gU2sBHXhOaK1hPh9v7rQtewN/eAEj8=",
-    "zh:03033fcd618042630a2f1cbe40f67baba814b2b5b893e89afd527bec1b143d6e",
-    "zh:24f7921f55786511fce6aee7325758f3c5d63bf2847cb875a0784602d3167602",
-    "zh:44c93b52ba7ebacbc6a62a4ff640f5c8ac99bcff30cdc8cca96aa86d37bd8b44",
+    "h1:XYdzJfs/iZw7GJpHgsDUPrPEkYA8JuutUNT9D2rJX0w=",
+    "zh:38178ff0047b1462c56299a45eb95c83c4a749c754112a41efd02609bca8abc5",
+    "zh:66cf6b6be572674363e15419a8ceadb3306d3bfdd1063a9da10fea103e099381",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a8c8e523b798b1bf887a8c036710678d31e9424cb55c7674cd9c9e03670552a4",
-    "zh:b89b2e629841e5762d2e21180b7546cb83fe58b2315eaccd199bbae5532a4e16",
-    "zh:c1ec8b8830b523bf09d1cab017268421771062be81a1c7a72688e75da75f71b7",
-    "zh:cb3bda3a18cdcf062c399210e5ab5df86ffe5ba4058e2e268d7250aee6968e7c",
-    "zh:eb306e5feebc27142fec11bc0bfe5cd836c6ef6ba272f69a2bf67412ca683d7b",
+    "zh:b135a73bf415b5ff4dde0c98f7b76c6d1c98fc7ab927a9ea38d34f74de80fe07",
+    "zh:b5ac0233964e0f6cd4acf2f7f0c8a750ccbd7183c759dd2d9ea1ca2e879c19b6",
+    "zh:ce75e08a2634e5aba7b55ced2503f44904bb2aa4793ee052d6697b1daec4f631",
+    "zh:cf40e590cf7e878693d373f96da0a1e9b56d8d8f48066bc9e78fdc34d1fa1661",
+    "zh:f8a6fe46b543be4c5590c71cc2891730a336a8cbe95e5b3f19f65d96c13b46a8",
+    "zh:f92c6523d65361df066697a6e857942c963dd227749523d3428eaca2aa54856a",
   ]
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -8,8 +8,8 @@ This module was created and maintained by the community. If you want to help, se
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.39.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
+| <a name="requirement_mgc"></a> [mgc](#requirement\_mgc) | ~> 0.44.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.2 |
 
 ## Providers

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,6 +15,5 @@ module "instance" {
   name              = "${var.name}-${random_string.sufix.id}"
   ssh_key_create    = false
   ssh_key_name      = "key-example"
-  machine_type_name = "BV2-2-10"
+  machine_type_name = "cloud-bs1.xsmall"
 }
-

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mgc = {
       source  = "MagaluCloud/mgc"
-      version = "~> 0.39.0"
+      version = "~> 0.44.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -51,26 +51,9 @@ resource "mgc_virtual_machine_instances" "this" {
   availability_zone        = length(var.availability_zone) > 0 ? var.availability_zone : null
   user_data                = length(var.user_data) > 0 ? base64encode(var.user_data) : null
   vpc_id                   = local.vpc_default_id
-  allocate_public_ipv4     = false
+  allocate_public_ipv4     = var.attach_public_ip
   creation_security_groups = length(local.resulting_security_group_ids) > 0 ? toset(sort(local.resulting_security_group_ids)) : null
   snapshot_id              = var.create_from_snapshot_id != null ? var.create_from_snapshot_id : null
-}
-
-resource "mgc_network_public_ips" "attach_public_ip" {
-  count       = var.create && var.attach_public_ip ? 1 : 0
-  description = "public ip ${mgc_virtual_machine_instances.this[0].name}"
-  vpc_id      = local.vpc_default_id
-}
-
-resource "mgc_network_public_ips_attach" "attach_public_ip" {
-  depends_on   = [mgc_virtual_machine_instances.this, mgc_network_public_ips.attach_public_ip]
-  count        = var.create && var.attach_public_ip ? 1 : 0
-  public_ip_id = mgc_network_public_ips.attach_public_ip[0].id
-  interface_id = mgc_virtual_machine_instances.this[0].network_interfaces[0].id
-  lifecycle {
-    create_before_destroy = true
-  }
-
 }
 
 resource "mgc_block_storage_volumes" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,7 @@ variable "additional_disk" {
   type        = any
 }
 
+#https://github.com/MagaluCloud/terraform-provider-mgc/issues/277
 variable "attach_public_ip" {
   description = "Attach public ip"
   type        = bool

--- a/version.tf
+++ b/version.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mgc = {
       source  = "MagaluCloud/mgc"
-      version = "~> 0.39.0"
+      version = "~> 0.44.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
Main Changes

MGC Provider Upgrade
Addition of Makefile: Implementation of standardized commands for the Terraform lifecycle:
make init, make plan, make apply, make destroy.
make clean: Deep cleanup of caches (.terraform), lock files, and local states (useful for provider upgrades).
make fmt, make validate, make docs: Quality assurance and automatic documentation.

Report on bug regarding public IP removal
https://github.com/MagaluCloud/terraform-provider-mgc/issues/277